### PR TITLE
Fix yt-dlp 403 errors from unwanted m4a extension in videos

### DIFF
--- a/packages/@uppy/companion/src/server/helpers/youtube_dl.js
+++ b/packages/@uppy/companion/src/server/helpers/youtube_dl.js
@@ -6,11 +6,10 @@ const TIMEOUT = 30 * 60 * 1000
 function streamFile (url, isAudio, output) {
   return youtubedl.exec(url, {
     output,
-    format: isAudio ? 'bestaudio[ext=m4a]/m4a' : 'worstvideo[height >= 480][ext=mp4]+[ext=m4a]/mp4',
+    format: isAudio ? 'bestaudio[ext=m4a]/m4a' : 'worstvideo[height >= 480][ext=mp4]/mp4',
 
     // Fixes 403s, as we are downloading from a different env than this
     noCacheDir: true,
-    rmCacheDir: true,
 
     maxFilesize: '10G',
     noPlaylist: true,


### PR DESCRIPTION
@zackbloom: no idea why this worked before, but eventually broke...

However, I confirmed that removing the `+[ext=m4a]` fixed video downloads on the companion server. Also, removed unnecessary duplication of cache disabling params (yt-dlp was giving me some noise about this).