### PR TITLE
Ensure yt-dlp gets audio w/video

### DIFF
--- a/packages/@uppy/companion/src/server/helpers/youtube_dl.js
+++ b/packages/@uppy/companion/src/server/helpers/youtube_dl.js
@@ -6,7 +6,9 @@ const TIMEOUT = 30 * 60 * 1000
 function streamFile (url, isAudio, output) {
   return youtubedl.exec(url, {
     output,
-    format: isAudio ? 'bestaudio[ext=m4a]/m4a' : 'worstvideo[height >= 480][ext=mp4]/mp4',
+
+    // "worst" requires both video and audio, instead of only one or the other
+    format: isAudio ? 'bestaudio[ext=m4a]/m4a' : 'worst[height >= 480][ext=mp4]/mp4',
 
     // Fixes 403s, as we are downloading from a different env than this
     noCacheDir: true,


### PR DESCRIPTION
Tested this locally; when using `worstvideo`, I get an mp4 that is only video. When using `worst`, I get video and audio. It looks like `worstvideo` was specifically telling `yt-dlp` to get the file w/o audio codec. @zackbloom was this intentional?