### PR TITLE
Forcing IPv4 in yt-dlp fixes 403 (temporarily?)

### DIFF
--- a/packages/@uppy/companion/src/server/helpers/youtube_dl.js
+++ b/packages/@uppy/companion/src/server/helpers/youtube_dl.js
@@ -16,6 +16,9 @@ function streamFile (url, isAudio, output) {
     maxFilesize: '10G',
     noPlaylist: true,
     retries: 1,
+
+    // fix HTTP 403? likely only temporarily / will still need proxy...
+    forceIpv4: true,
   }, {
     timeout: TIMEOUT,
   })


### PR DESCRIPTION
FYI @zackbloom; I think this only works because it makes the requesting IP look different and could get blocked again at anytime, but may save some money while we wait for actually needing a proxy service like Oxylabs.