### PR TITLE
Revert "Forcing IPv4 in yt-dlp fixes 403 (temporarily?)"

### DIFF
--- a/packages/@uppy/companion/src/server/helpers/youtube_dl.js
+++ b/packages/@uppy/companion/src/server/helpers/youtube_dl.js
@@ -16,9 +16,6 @@ function streamFile (url, isAudio, output) {
     maxFilesize: '10G',
     noPlaylist: true,
     retries: 1,
-
-    // fix HTTP 403? likely only temporarily / will still need proxy...
-    forceIpv4: true,
   }, {
     timeout: TIMEOUT,
   })


### PR DESCRIPTION
this may fix problems we're seeing now:
```
WARNING: [youtube] Skipping player response from ios client (got player response for video "M5t4UHllkUM" instead of "zhWDdy_5v2w"); please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
[youtube] zhWDdy_5v2w: Downloading android player API JSON
WARNING: [youtube] Skipping player response from android client (got player response for video "M5t4UHllkUM" instead of "zhWDdy_5v2w"); please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
WARNING: [youtube] Skipping player response from web client (got player response for video "M5t4UHllkUM" instead of "zhWDdy_5v2w"); please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
WARNING: Only images are available for download. use --list-formats to see them
```